### PR TITLE
Fix outdated import path for get_wallet

### DIFF
--- a/cic/cli/clients.py
+++ b/cic/cli/clients.py
@@ -3,7 +3,7 @@ import aiohttp
 from pprint import pprint
 from typing import Optional
 
-from chia.cmds.wallet_funcs import get_wallet
+from chia.cmds.cmds_util import get_wallet
 from chia.rpc.full_node_rpc_client import FullNodeRpcClient
 from chia.rpc.wallet_rpc_client import WalletRpcClient
 from chia.util.config import load_config


### PR DESCRIPTION
Function was moved here https://github.com/Chia-Network/chia-blockchain/commit/baaa77b71d92668640fec820ca883425b4b7accf