### PR TITLE
Remove support for python3.9 and move core ops to 3.12

### DIFF
--- a/.github/workflows/run-test-suite.yml
+++ b/.github/workflows/run-test-suite.yml
@@ -6,10 +6,10 @@ on:
     branches:
       - main
     tags:
-        - '**'
+      - "**"
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}--${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
@@ -22,19 +22,19 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - name: Checkout Code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: Setup Python environment
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.9
+      - name: Setup Python environment
+        uses: Chia-Network/actions/setup-python@main
+        with:
+          python-version: 3.12
 
-    - name: Test code with pytest
-      run: |
-        python3 -m venv venv
-        . ./venv/bin/activate
-        pip install .[dev]
-        ./venv/bin/py.test tests/ -s -v --durations 0
+      - name: Test code with pytest
+        run: |
+          python3 -m venv venv
+          . ./venv/bin/activate
+          pip install .[dev]
+          ./venv/bin/py.test tests/ -s -v --durations 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=80",
     "wheel",
-    "setuptools_scm>=6.4"
+    "setuptools_scm>=8"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -13,7 +13,3 @@ line-length = 120
 max-line-length = 120
 exclude = "./typings/**/*"
 ignore = "E203,W503"
-
-[tool.setuptools_scm]
-fallback_version = "unknown-no-.git-directory"
-local_scheme = "no-local-version"

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,9 @@ setup(
     long_description_content_type="text/markdown",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Topic :: Security :: Cryptography",
     ],


### PR DESCRIPTION
This PR drops support for Python3.9 which is EOL at the end of October and switches core operations from 3.10 (now the lowest supported version) to 3.12.

(My editor also linted the yaml)